### PR TITLE
Add Railway deployable example

### DIFF
--- a/railway-app/package.json
+++ b/railway-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tiptap-railway-app",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/railway-app/public/App.js
+++ b/railway-app/public/App.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from 'react'
+
+export default function App() {
+  const editorContainer = useRef(null)
+
+  useEffect(() => {
+    let editor
+    ;(async () => {
+      const { Editor } = await import('https://esm.sh/@tiptap/core@2?bundle')
+      const StarterKit = (await import('https://esm.sh/@tiptap/starter-kit@2?bundle')).default
+      const Collaboration = (await import('https://esm.sh/@tiptap/extension-collaboration@2?bundle')).default
+      const CollaborationCursor = (await import('https://esm.sh/@tiptap/extension-collaboration-cursor@2?bundle')).default
+      const ContentAI = (await import('https://esm.sh/@tiptap-pro/extension-content-ai?bundle')).default
+      const Y = await import('https://esm.sh/yjs@13?bundle')
+      const { WebsocketProvider } = await import('https://esm.sh/y-websocket@1?bundle')
+
+      const ydoc = new Y.Doc()
+      const provider = new WebsocketProvider('wss://collab.tiptap.dev', 'example-doc', ydoc)
+
+      editor = new Editor({
+        element: editorContainer.current,
+        extensions: [
+          StarterKit,
+          Collaboration.configure({ document: ydoc }),
+          CollaborationCursor.configure({ provider }),
+          ContentAI.configure({ apiKey: 'YOUR_OPENAI_KEY' })
+        ],
+        content: '<p>Hello World!</p>'
+      })
+    })()
+
+    return () => {
+      if (editor) editor.destroy()
+    }
+  }, [])
+
+  return React.createElement('div', { className: 'editor', ref: editorContainer })
+}

--- a/railway-app/public/app.js
+++ b/railway-app/public/app.js
@@ -1,0 +1,6 @@
+import App from './App.js'
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+
+const root = createRoot(document.getElementById('root'))
+root.render(React.createElement(App))

--- a/railway-app/public/index.html
+++ b/railway-app/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tiptap Railway Example</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/railway-app/public/styles.css
+++ b/railway-app/public/styles.css
@@ -1,0 +1,12 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+.editor {
+  max-width: 700px;
+  margin: 2rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  min-height: 300px;
+}

--- a/railway-app/server.js
+++ b/railway-app/server.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const path = require('path')
+const app = express()
+const port = process.env.PORT || 3000
+
+app.use(express.static(path.join(__dirname, 'public')))
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`)
+})


### PR DESCRIPTION
## Summary
- add a small Express server with a static React page
- use Tiptap collaboration & ContentAI via CDN imports

## Testing
- `npm run build` *(fails: rollup not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867227b3ef88330b5e3d0538b7c1854