### PR TITLE
Create doc on page load

### DIFF
--- a/railway-app/public/App.js
+++ b/railway-app/public/App.js
@@ -4,7 +4,13 @@ export default function App() {
   const editorContainer = useRef(null)
   const envRef = useRef(null)
   const editorRef = useRef(null)
-  const [docId, setDocId] = useState(() => window.location.hash.slice(1))
+  const [docId, setDocId] = useState(() => {
+    const existing = window.location.hash.slice(1)
+    if (existing) return existing
+    const id = Math.random().toString(36).slice(2, 10)
+    window.location.hash = id
+    return id
+  })
   const [envLoaded, setEnvLoaded] = useState(false)
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- generate a document ID if none is present and update location hash
- load the editor with this document once env is loaded

## Testing
- `npm install`
- `npm start` (fails without environment variables, but server starts)

------
https://chatgpt.com/codex/tasks/task_e_68673d5920288330b49b1b5772db6f0c