### PR TITLE
Update port binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install
 npm start
 ```
 
-The server will run on `PORT` (defaults to `3000`) and serve the files in `railway-app/public`.
+The server will run on `PORT` (defaults to `8080`) and serve the files in `railway-app/public`.
 
 ## Environment Variables
 

--- a/railway-app/server.js
+++ b/railway-app/server.js
@@ -3,7 +3,7 @@ const path = require('path')
 const jwt = require('jsonwebtoken')
 require('dotenv').config()
 const app = express()
-const port = process.env.PORT || 3000
+const port = process.env.PORT || 8080
 
 app.use(express.static(path.join(__dirname, 'public')))
 


### PR DESCRIPTION
## Summary
- use `process.env.PORT` with 8080 fallback
- update readme default port

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68673f50c0f48330badb17bff80321af